### PR TITLE
Shard selecting by payoff threshold

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ mainClass in Compile := Some("edu.nyu.tandon.search.selective.Run")
 
 libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt" % "3.5.0",
-  "org.scalatest" %% "scalatest" % "3.0.0" % "test",
+  "org.scalatest" %% "scalatest" % "2.2.5" % "test",
   "commons-io" % "commons-io" % "2.5",
   "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",

--- a/src/main/scala/edu/nyu/tandon/search/selective/package.scala
+++ b/src/main/scala/edu/nyu/tandon/search/selective/package.scala
@@ -10,9 +10,11 @@ package object selective {
 
   val NestingIndicator = "#"
   val BudgetIndicator = "$"
+  val ThresholdIndicator = "%"
 
   def base(nestedBasename: String): String = nestedBasename
     .takeWhile(c => s"$c" != NestingIndicator)
     .takeWhile(c => s"$c" != BudgetIndicator)
+    .takeWhile(c => s"$c" != ThresholdIndicator)
 
 }


### PR DESCRIPTION
Additionally, downgrade of scalatest to 2.2.5 due to the following problem: http://stackoverflow.com/questions/39924928/scalatest-v3-why-require-to-implement-converttolegacyequalizer